### PR TITLE
fix(clifford): set point size before drawArrays call

### DIFF
--- a/src/components/clifford/Attractor.svelte
+++ b/src/components/clifford/Attractor.svelte
@@ -223,6 +223,7 @@
 
 				void main() {
 					gl_Position = vec4(position * scale + offset, 0.0, 1.0);
+					gl_PointSize = 1.0;
 				}`,
 			);
 


### PR DESCRIPTION
Without it, some platforms (seemingly windows?) with hardware acceleration won't render the drawArrays call without throwing an error.